### PR TITLE
Log activation sparsity levels 

### DIFF
--- a/S5/s5/shift_add_layers.py
+++ b/S5/s5/shift_add_layers.py
@@ -225,7 +225,9 @@ class SequenceLayer(nn.Module):
 
         if self.activation in ["full_glu"]:
             x = self.drop(self.pre_act(x))
+            self.sow("intermediates", "pre_act_x", x)  # NOTE: records activation sparsity
             x = self.out1(x) * jax.nn.sigmoid(self.out2(x))
+            self.sow("intermediates", "glu_x", x)
             x = self.drop(x)
         elif self.activation in ["half_glu1"]:
             x = self.drop(self.pre_act(x))

--- a/S5/s5/train.py
+++ b/S5/s5/train.py
@@ -194,14 +194,21 @@ def train(args):
         lr_params = (decay_function, ssm_lr, lr, step, end_step, args.opt_config, args.lr_min)
 
         train_rng, skey = random.split(train_rng)
-        state, train_loss, step = train_epoch(state,
-                                              skey,
-                                              model_cls,
-                                              trainloader,
-                                              seq_len,
-                                              in_dim,
-                                              args.batchnorm,
-                                              lr_params)
+        state, train_loss, step, act_sparsities = train_epoch(
+            state,
+            skey,
+            model_cls,
+            trainloader,
+            seq_len,
+            in_dim,
+            args.batchnorm,
+            lr_params,
+            log_act_sparsity=True,
+        )
+        act_sparsity_logs = {f"act_sparsity/train/{k}": v for k, v in act_sparsities.items()}
+        # NOTE: for now, just print the sparsity levels, later log them to W&B
+        # wandb.log(**act_sparsity_logs, step=step)
+        print(act_sparsity_logs)
 
         if valloader is not None:
             print(f"[*] Running Epoch {epoch + 1} Validation...")


### PR DESCRIPTION
Using `sow` to log sparsity of intermediate activations in the forward pass. Can log the activation sparsity in additional places by simply adding the line `self.sow("intermediates", activation_name, x)` (where `x` is the array containing the activations to be analyzed) anywhere in a flax module's __call__ or apply method.